### PR TITLE
Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,15 +9,11 @@ ifeq ($(shell uname -s | grep -c -m 1 -E '^(MSYS|MINGW).*'),1)
 GO_BUILD_OUTPUT := $(shell cygpath -w "$(OUTPUT)")
 endif
 
-SRC             := $(shell find . -type f -name '*.go' -print) go.mod
-
 .PHONY: all
 all: build
 
 .PHONY: build
-build: $(OUTPUT)
-
-$(OUTPUT): $(SRC)
+build:
 	CGO_ENABLED=0 '$(GO)' build -trimpath -o '$(GO_BUILD_OUTPUT)' ./cmd/go-error-handling
 
 .PHONY: clean


### PR DESCRIPTION
Removed dependency of build Makefile target on source files, because it is broken when one of source files is removed (make doesn't detect change and doesn't rebuild).