### PR TITLE
Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,4 +44,4 @@ run:
 
 .PHONY: clean
 clean:
-	rm -f $(call squote,$(OUTPUT))
+	$(RM) $(call squote,$(OUTPUT))


### PR DESCRIPTION
Using make built-in "RM" variable (refer to https://www.gnu.org/software/make/manual/html_node/Implicit-Variables.html) for removal of build output in "clean" make target.